### PR TITLE
allow serving static files from the tiles/ directory

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -2,4 +2,6 @@ Options -Indexes
 Options +FollowSymLinks
 Options -MultiViews
 RewriteEngine On
+RewriteCond %{REQUEST_FILENAME} -f
+RewriteCond %{REQUEST_FILENAME} -d
 RewriteRule ^(.*)$ tileserver.php [QSA,L]


### PR DESCRIPTION
if static files (and sub-directories) are present, don't route through tileserver.php
this allows:
1. to switch from a static tree to an .mbtiles, and back, without changing URLs
2. to roughly build a cache for (a subset of) the tiles
